### PR TITLE
Added Mock Tests for LLM in Translator Service

### DIFF
--- a/.github/workflows/f24_teampawsitive-translator.yml
+++ b/.github/workflows/f24_teampawsitive-translator.yml
@@ -7,7 +7,7 @@ name: Build and deploy Python app to Azure Web App - teampawsitive-translator
 on:
   push:
     branches:
-      - Mocking_tests
+      - Mocking-tests
       - f24
   workflow_dispatch:
 

--- a/.github/workflows/f24_teampawsitive-translator.yml
+++ b/.github/workflows/f24_teampawsitive-translator.yml
@@ -7,6 +7,7 @@ name: Build and deploy Python app to Azure Web App - teampawsitive-translator
 on:
   push:
     branches:
+      - Mocking_test
       - f24
   workflow_dispatch:
 

--- a/.github/workflows/f24_teampawsitive-translator.yml
+++ b/.github/workflows/f24_teampawsitive-translator.yml
@@ -7,7 +7,7 @@ name: Build and deploy Python app to Azure Web App - teampawsitive-translator
 on:
   push:
     branches:
-      - Mocking_test
+      - Mocking_tests
       - f24
   workflow_dispatch:
 

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -1,13 +1,56 @@
-from src.translator import translate_content
-
+from unittest.mock import patch
+from src.translator import translate_content, query_llm_robust
+import openai
 
 def test_chinese():
     is_english, translated_content = translate_content("这是一条中文消息")
     assert is_english == False
     assert translated_content == "This is a Chinese message"
 
-def test_llm_normal_response():
-    pass
+@patch.object(openai.ChatCompletion, 'create')
+def test_llm_normal_response(mocker):
+    """
+    Test for a normal response from the LLM where the input is translated properly.
+    """
+    # Mock the model's response to return a valid translation
+    mocker.return_value.choices[0].message.content = "The translation is: This is your first example."
 
-def test_llm_gibberish_response():
-    pass
+    # Assert that query_llm_robust handles valid translation correctly
+    result = query_llm_robust("Hier ist dein erstes Beispiel.")
+    assert result == (False, "This is your first example."), "Failed to handle normal response correctly"
+
+@patch.object(openai.ChatCompletion, 'create')
+def test_llm_gibberish_response(mocker):
+    """
+    Test for handling a gibberish response from the LLM.
+    """
+    # Mock the model's response to return 'Unintelligible'
+    mocker.return_value.choices[0].message.content = "Unintelligible"
+
+    # Assert that query_llm_robust handles gibberish input gracefully
+    result = query_llm_robust("asdkjhf aksdfjhas dfkljha sd")
+    assert result == (False, "Unintelligible"), "Failed to handle gibberish response correctly"
+
+@patch.object(openai.ChatCompletion, 'create')
+def test_llm_unexpected_language(mocker):
+    """
+    Test for an unexpected response format from the LLM.
+    """
+    # Mock the model's response to return an unexpected message
+    mocker.return_value.choices[0].message.content = "I don't understand your request"
+
+    # Assert that query_llm_robust handles this gracefully
+    result = query_llm_robust("Bonjour tout le monde!")
+    assert result == (False, "Error: Unexpected response format"), "Failed to handle unexpected language response"
+
+@patch.object(openai.ChatCompletion, 'create')
+def test_llm_api_error(mocker):
+    """
+    Test for handling an API error gracefully.
+    """
+    # Simulate an API error by raising an exception in the mock
+    mocker.side_effect = Exception("API request failed")
+
+    # Assert that query_llm_robust returns a safe fallback response
+    result = query_llm_robust("今日はとてもいい天気ですね。")
+    assert result == (False, "Error: Unable to process request"), "Failed to handle API error gracefully"

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -27,7 +27,7 @@ def test_llm_gibberish_response(mocker):
     # Mock the model's response to return 'Unintelligible'
     mocker.return_value.choices[0].message.content = "Unintelligible"
 
-    # Assert that query_llm_robust handles gibberish input gracefully
+    # Assert that query_llm_robust handles gibberish inputt gracefully
     result = query_llm_robust("asdkjhf aksdfjhas dfkljha sd")
     assert result == (False, "Unintelligible"), "Failed to handle gibberish response correctly"
 

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -51,6 +51,6 @@ def test_llm_api_error(mocker):
     # Simulate an API error by raising an exception in the mock
     mocker.side_effect = Exception("API request failed")
 
-    # Assert that query_llm_robust returns a safe fallback response
+    # Assert that query_llm_robust returns a safe fallback responses
     result = query_llm_robust("今日はとてもいい天気ですね。")
     assert result == (False, "Error: Unable to process request"), "Failed to handle API error gracefully"

--- a/test/unit/test_translator.py
+++ b/test/unit/test_translator.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-from src.translator import translate_content, query_llm_robust
+from src.translator import translate_content
 import openai
 
 def test_chinese():
@@ -16,7 +16,7 @@ def test_llm_normal_response(mocker):
     mocker.return_value.choices[0].message.content = "The translation is: This is your first example."
 
     # Assert that query_llm_robust handles valid translation correctly
-    result = query_llm_robust("Hier ist dein erstes Beispiel.")
+    result = translate_content("Hier ist dein erstes Beispiel.")
     assert result == (False, "This is your first example."), "Failed to handle normal response correctly"
 
 @patch.object(openai.ChatCompletion, 'create')
@@ -28,7 +28,7 @@ def test_llm_gibberish_response(mocker):
     mocker.return_value.choices[0].message.content = "Unintelligible"
 
     # Assert that query_llm_robust handles gibberish inputt gracefully
-    result = query_llm_robust("asdkjhf aksdfjhas dfkljha sd")
+    result = translate_content("asdkjhf aksdfjhas dfkljha sd")
     assert result == (False, "Unintelligible"), "Failed to handle gibberish response correctly"
 
 @patch.object(openai.ChatCompletion, 'create')
@@ -40,7 +40,7 @@ def test_llm_unexpected_language(mocker):
     mocker.return_value.choices[0].message.content = "I don't understand your request"
 
     # Assert that query_llm_robust handles this gracefully
-    result = query_llm_robust("Bonjour tout le monde!")
+    result = translate_content("Bonjour tout le monde!")
     assert result == (False, "Error: Unexpected response format"), "Failed to handle unexpected language response"
 
 @patch.object(openai.ChatCompletion, 'create')
@@ -52,5 +52,5 @@ def test_llm_api_error(mocker):
     mocker.side_effect = Exception("API request failed")
 
     # Assert that query_llm_robust returns a safe fallback responses
-    result = query_llm_robust("今日はとてもいい天気ですね。")
+    result = translate_content("今日はとてもいい天気ですね。")
     assert result == (False, "Error: Unable to process request"), "Failed to handle API error gracefully"


### PR DESCRIPTION
This pull request is a continuation of https://github.com/fdounis/translator-service/pull/1, where the Translator Service was modified to use a real LLM, rather than hard-coded responses.

This PR adds four new mock tests to improve the robustness of the query_llm_robust function, ensuring it handles various edge cases and errors effectively. The tests include: test_llm_normal_response, which verifies the correct handling of a valid LLM response with accurate translations; test_llm_gibberish_response, which ensures gibberish inputs are identified and appropriately flagged as "Unintelligible"; test_llm_unexpected_language, which tests the system's resilience to unexpected response formats from the LLM; and test_llm_api_error, which simulates API failures and checks if the function provides a safe fallback response. These tests use unittest.mock.patch to simulate LLM behavior, replacing actual API calls with predefined mock responses. By adding these cases to the test_translator.py file, the system is better equipped to manage diverse scenarios, ensuring reliable performance and graceful error handling.

![WhatsApp Image 2024-11-19 at 1 39 10 PM](https://github.com/user-attachments/assets/1a2af13e-e389-488d-97da-ca8d82a00da6)
